### PR TITLE
fix jira/ADC-2271

### DIFF
--- a/Agora-Video-With-FaceUnity-Android/faceunity/src/main/java/com/faceunity/FURenderer.java
+++ b/Agora-Video-With-FaceUnity-Android/faceunity/src/main/java/com/faceunity/FURenderer.java
@@ -1047,7 +1047,8 @@ public class FURenderer implements OnFUControlListener {
             isNeedUpdateFaceBeauty = false;
         }
 
-        if (mItemsArray[ITEM_ARRAYS_EFFECT_INDEX] > 0 && mDefaultEffect.effectType() == Effect.EFFECT_TYPE_GESTURE) {
+        if (mItemsArray[ITEM_ARRAYS_EFFECT_INDEX] > 0 && mDefaultEffect != null &&
+                mDefaultEffect.effectType() == Effect.EFFECT_TYPE_GESTURE) {
             faceunity.fuItemSetParam(mItemsArray[ITEM_ARRAYS_EFFECT_INDEX], "rotMode", mRotMode);
         }
         //queueEvent的Runnable在此处被调用


### PR DESCRIPTION
FURenderer did not do a Null-Pointer-Exception check while the default effect is allowed to be null.
All other places where mDefaultEffect is used perform such NPE checks before accessing its reference.