### PR TITLE
解决一个隐藏引起横屏渲染的bug

### DIFF
--- a/Agora-Video-With-FaceUnity-iOS/AgoraWithFaceunity/Controllers/RoomViewController.m
+++ b/Agora-Video-With-FaceUnity-iOS/AgoraWithFaceunity/Controllers/RoomViewController.m
@@ -90,25 +90,6 @@
 
 - (void)viewWillLayoutSubviews {
     [super viewWillLayoutSubviews];
-    UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
-
-    switch (orientation) {
-        case UIInterfaceOrientationPortrait:
-            [self.mCamera setCaptureVideoOrientation:AVCaptureVideoOrientationPortrait];
-            break;
-        case UIInterfaceOrientationPortraitUpsideDown:
-            [self.mCamera setCaptureVideoOrientation:AVCaptureVideoOrientationPortraitUpsideDown];
-            break;
-        case UIInterfaceOrientationLandscapeLeft:
-            [self.mCamera setCaptureVideoOrientation:AVCaptureVideoOrientationLandscapeLeft];
-            break;
-        case UIInterfaceOrientationLandscapeRight:
-            [self.mCamera setCaptureVideoOrientation:AVCaptureVideoOrientationLandscapeRight];
-            break;
-
-        default:
-            break;
-    }
 }
 
 - (void)viewDidLayoutSubviews {
@@ -460,6 +441,7 @@
     //Change camera need to call below function
     [self.agoraKit switchCamera];
     [[FUManager shareManager] onCameraChange];
+    [self setCaptureVideoOrientation];
 }
 
 - (IBAction)muteBtnClick:(UIButton *)sender {
@@ -470,6 +452,27 @@
 
 - (IBAction)buglyBtnClick:(UIButton *)sender {
     self.buglyLabel.hidden = !self.buglyLabel.hidden;
+}
+
+- (void)setCaptureVideoOrientation {
+    UIInterfaceOrientation orientation = [UIApplication sharedApplication].statusBarOrientation;
+
+    switch (orientation) {
+        case UIInterfaceOrientationPortrait:
+            [self.mCamera setCaptureVideoOrientation:AVCaptureVideoOrientationPortrait];
+            break;
+        case UIInterfaceOrientationPortraitUpsideDown:
+            [self.mCamera setCaptureVideoOrientation:AVCaptureVideoOrientationPortraitUpsideDown];
+            break;
+        case UIInterfaceOrientationLandscapeLeft:
+            [self.mCamera setCaptureVideoOrientation:AVCaptureVideoOrientationLandscapeLeft];
+            break;
+        case UIInterfaceOrientationLandscapeRight:
+            [self.mCamera setCaptureVideoOrientation:AVCaptureVideoOrientationLandscapeRight];
+            break;
+        default:
+            break;
+    }
 }
 
 #pragma mark --- FUItemsViewDelegate


### PR DESCRIPTION
删除掉下面这行代码会引起切换摄像头后渲染横屏。`self.buglyLabel.text = [NSString stringWithFormat:@"resolution:\n %@\nfps: %.0f \nrender time:\n %.0fms", ratioStr, fps, renderTime * 1000.0]; ` 
原因是因为setVideoOrientation 这个方法之前放在了监听页面layout的里面，导致注释掉这行代码，页面就没有重新layout的情况，导致不去设置setVideoOrientation。 系统给的buffer是横屏的，渲染错误。还存在一个在layout里面不断设置setVideoOrientation 的隐形问题。

修改 把setVideoOrientation 方法移动到了，切换前后摄像头的里面，而且每次只执行一次。